### PR TITLE
STUD-935 Add Workiva CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github/
+.gitignore
+.dockerignore
+.idea/
+*/target/
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Purpose
+
+Brief description of the purpose of this change.
+
+## Solution
+
+High level overview of what was done. This is the roadmap for those who are going to CR.
+
+## Semantic Versioning (check one)
+
+- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
+    - *[link to the breaking change in the diff]*
+- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
+- [ ] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
+  release
+
+## How to QA
+
+- [ ] run the following related examples: **(fill in)**
+- [ ] Other necessary steps needed to fully exercise the solution should be added here. **(fill in)**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+registries:
+  maven-repository-workivaeast-jfrog-io-workivaeast-maven-prod:
+    type: maven-repository
+    url: https://workivaeast.jfrog.io/workivaeast/maven-prod
+    username: "${{secrets.WORKIVA_ARTIFACTORY_JFROG_USERNAME}}"
+    password: "${{secrets.WORKIVA_ARTIFACTORY_JFROG_PASSWORD}}"
+
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - maven-repository-workivaeast-jfrog-io-workivaeast-maven-prod
+    schedule:
+      interval: "weekly"
+      day: sunday
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ registries:
     password: "${{secrets.WORKIVA_ARTIFACTORY_JFROG_PASSWORD}}"
 
 updates:
-  - package-ecosystem: "gradle"
+  - package-ecosystem: "maven"
     directory: "/"
     registries:
       - maven-repository-workivaeast-jfrog-io-workivaeast-maven-prod

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea/
 /target

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN yum install tar gzip -y
 
 COPY pom.xml /build/pom.xml
 
-# run to pull down the gradle wrapper and cache that on its own layer
 RUN mvn --version
 
 COPY . .
@@ -16,6 +15,7 @@ ARG GIT_TAG
 # Build the application.
 #
 RUN ./scripts/build.sh
+
 # Collect assembled jar for publishing
 ARG BUILD_ARTIFACTS_JAVA=/build/target/*.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM maven:3.8.5-amazoncorretto-8 AS build
+WORKDIR /build
+
+RUN yum install tar gzip -y
+
+COPY pom.xml /build/pom.xml
+
+# run to pull down the gradle wrapper and cache that on its own layer
+RUN mvn --version
+
+COPY . .
+
+ARG GIT_BRANCH
+ARG GIT_TAG
+
+# Build the application.
+#
+RUN ./scripts/build.sh
+# Collect assembled jar for publishing
+ARG BUILD_ARTIFACTS_JAVA=/build/target/*.jar
+
+# Generate Veracode Artifact
+RUN tar -cvzf /java.tar.gz /build/target/*.jar
+ARG BUILD_ARTIFACTS_VERACODE=/java.tar.gz
+ARG BUILD_ARTIFACTS_POM=/build/pom.xml
+
+# We only care about publishing a jar
+FROM scratch

--- a/aviary.yaml
+++ b/aviary.yaml
@@ -1,0 +1,1 @@
+version: 1

--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <include>pom.xml</include>
-                    </includes>
-                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>pom.xml</include>
+                    </includes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.jcraft</groupId>
     <artifactId>jsch</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.57.ONECLOUD</version>
+    <version>0.1.57-SNAPSHOT</version>
     <name>JSch</name>
     <url>http://www.jcraft.com/jsch/</url>
     <description>JSch is a pure Java implementation of SSH2</description>
@@ -72,7 +72,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <target>1.5</target>
+                    <target>1.8</target>
+                    <source>1.8</source>
                 </configuration>
             </plugin>
             <plugin>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ exit=0
 eval "${BUILD_CMD}" || exit=$?
 
 # RM currently requires all JAR files to contain a pom.xml for publishing; sources/javadocs don't (and shouldn't).
-# Note 1.4.22 - BUILDTOOLS-3344 was closed with a disposition of 'Will Not Do'.
+# BUILDTOOLS-3344 was closed with a disposition of 'Will Not Do'.
 # For the forseeable future, need to inject a pom.xml into the javadocs jar
 find ./target -name "jsch-*-*javadoc.jar" | xargs -I '{}' jar uvf {} pom.xml
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-
 BUILD_CMD="mvn package"
 
 if [ "${GIT_TAG}" ]
 then
   RELEASE_VERSION=${GIT_TAG}
 	echo "Detected tagged build version ${GIT_TAG}. Setting version to ${RELEASE_VERSION}"
-	BUILD_CMD+=" -DarchetypeVersion=${RELEASE_VERSION}"
+	mvn versions:set -DnewVersion=${GIT_TAG}
 else
 	echo "No tag detected on the current commit. This is a non-release build."
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,4 +14,10 @@ fi
 echo "Executing build as: ${BUILD_CMD}"
 exit=0
 eval "${BUILD_CMD}" || exit=$?
+
+# RM currently requires all JAR files to contain a pom.xml for publishing; sources/javadocs don't (and shouldn't).
+# Note 1.4.22 - BUILDTOOLS-3344 was closed with a disposition of 'Will Not Do'.
+# For the forseeable future, need to inject a pom.xml into the javadocs jar
+find ./target -name "jsch-*-*javadoc.jar" | xargs -I '{}' jar uvf {} pom.xml
+
 exit $exit

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+BUILD_CMD="mvn package"
+
+if [ "${GIT_TAG}" ]
+then
+  RELEASE_VERSION=${GIT_TAG}
+	echo "Detected tagged build version ${GIT_TAG}. Setting version to ${RELEASE_VERSION}"
+	BUILD_CMD+=" -DarchetypeVersion=${RELEASE_VERSION}"
+else
+	echo "No tag detected on the current commit. This is a non-release build."
+fi
+
+echo "Executing build as: ${BUILD_CMD}"
+exit=0
+eval "${BUILD_CMD}" || exit=$?
+exit $exit

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,0 +1,17 @@
+# Testing with Skynet - https://github.com/Workiva/skynet/tree/master/docs
+name: jsch-tests
+image: amazoncorretto:8
+description: run jsch unit tests
+timeout: 300 #5 minutes
+size: small
+contact: support-onecloud
+
+run:
+  on-pull-request: yes
+  on-tag: yes
+  when-branch-name-is:
+    - ^refs/tags/.+
+    - master
+
+scripts:
+  - echo 'This repository does not contain tests.'


### PR DESCRIPTION
## Ticket

https://jira.atl.workiva.net/browse/STUD-803

Sets up Basic Workiva CI processes
- Dockerfile
- skynet.yaml
- dependabot
- aviary

## QA
- [x] Build artifacts contain: 
    - [x] .jar
    - [x] sources.jar
    - [x] javadoc.jar
- [x] Package appears on `maven-dev-internal` in Artifactory ([Link to artifactory](https://workivaeast.jfrog.io/ui/packages/gav:%2F%2Fcom.jcraft:jsch?name=jsch&type=packages))
- [x] Skynet results show same number of tests as previous CI runner (There are no tests in this repo, [ticket created for testing](https://jira.atl.workiva.net/browse/STUD-1122))
